### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The goal of this component is to collect and list all the deprecation of the pro
 
 ## Installation
 
-Add `gem 'deprecations_collector', github: 'nebulab/deprecations_collector'` to your application's Gemfile and execute `bundle`.
+Add `gem 'deprecations_collector', git: 'https://github.com/nebulab/deprecations_collector'` to your application's Gemfile and execute `bundle`.
 
 Put the following code under you specs configuration:
 


### PR DESCRIPTION
Otherwise you get:
The git source `git://github.com/nebulab/deprecations_collector.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.